### PR TITLE
Adding the ability to use an already existing connection

### DIFF
--- a/lib/redis_ascoltatore.js
+++ b/lib/redis_ascoltatore.js
@@ -120,7 +120,10 @@ function containsWildcard(topic) {
 }
 
 function createConn(opts) {
-  var conn = opts.redis.createClient(opts.port, opts.host, opts);
+  var conn = opts.client;
+  if (opts.client == undefined){
+    conn = opts.redis.createClient(opts.port, opts.host, opts);
+  }
   conn.select(opts.db || 0);
   conn.retry_backoff = 5;
   return conn;

--- a/test/redis_ascoltatore_spec.js
+++ b/test/redis_ascoltatore_spec.js
@@ -1,3 +1,4 @@
+var assert = require("assert");
 
 describe(ascoltatori.RedisAscoltatore, function() {
 
@@ -27,4 +28,12 @@ describe(ascoltatori.RedisAscoltatore, function() {
       }
     ]);
   });
+
+  it('should get the redis client already created', function alreadyCreated(){
+    var opts = redisSettings();
+    var initialConnection = opts.redis.createClient(opts.port, opts.host, opts);
+    opts.client = initialConnection;
+    var other = new ascoltatori.RedisAscoltatore(opts);
+    assert.equal(initialConnection, other._client_conn);
+  })
 });


### PR DESCRIPTION
I needed the ability to use an already existing connection instead of create a new one with ascoltatori. So I added that option.
