### PR TITLE
MQTTAscoltatore sends a clientId greater than 23 chars

### DIFF
--- a/lib/mqtt_ascoltatore.js
+++ b/lib/mqtt_ascoltatore.js
@@ -13,6 +13,7 @@ var SubsCounter = require("./subs_counter");
  * backed up by any MQTT broker out there.
  *
  * The options are:
+ *  - `clientId`, the id of the MQTT client (max 23 chars)
  *  - `keepalive`, the keepalive timeout in seconds (see the MQTT spec), the default is 3000;
  *  - `port`, the port to connect to;
  *  - `host`, the host to connect to;
@@ -26,7 +27,6 @@ function MQTTAscoltatore(opts) {
 
   this._opts = opts || {};
   this._opts.keepalive = this._opts.keepalive || 3000;
-  this._opts.qos = this._opts.qos || 0;
   this._opts.mqtt = this._opts.mqtt || require("mqtt");
 
   this._subs_counter = new SubsCounter();
@@ -54,8 +54,7 @@ MQTTAscoltatore.prototype._startConn = function() {
   if (this._client === undefined) {
     settings = {
       keepalive: that._opts.keepalive,
-      clientId: util.buildIdentifier(),
-      qos: that._opts.qos
+      clientId: that._opts.clientId,
     };
 
     debug("connecting..");


### PR DESCRIPTION
The spec says that a clientId must be in 23 chars.
