### PR TITLE
Update json_ascoltatore.js

### DIFF
--- a/lib/json_ascoltatore.js
+++ b/lib/json_ascoltatore.js
@@ -28,7 +28,11 @@ JSONAscoltatore.prototype.wrapCallback = function(callback, next) {
   if (!callback._json_ascoltatore_wrapper) {
     callback._json_ascoltatore_wrapper = function(t, payload) {
       debug("converting from JSON");
-      callback(t, JSON.parse(payload));
+      try {
+        callback(t, JSON.parse(payload));
+      } catch (e) {
+        console.log("The payload is not a valid JSON", e);
+      }
     };
   }
   next(null, callback._json_ascoltatore_wrapper);


### PR DESCRIPTION
Catch the error raised when the JSON published from the client is not valid. I've added a basic console.log to show the message, as the debug isn't be visible if the related env var is not set. In this way the services receiving wrong JSON still work.
