### PR TITLE
MongoDB binary payloads.

### DIFF
--- a/lib/mongo_ascoltatore.js
+++ b/lib/mongo_ascoltatore.js
@@ -198,8 +198,15 @@ MongoAscoltatore.prototype._more = function(latest) {
     if (doc._id > latest) {
       latest = doc._id;
       process.nextTick(function() {
+        var value;
         if (!that._closed) {
-          that._ascoltatore.publish(doc.topic, doc.value);
+          if (doc.value && doc.value.buffer) {
+            value = doc.value.buffer;
+          } else {
+            value = doc.value;
+          }
+
+          that._ascoltatore.publish(doc.topic, value);
         }
       });
     }

--- a/test/mongo_ascoltatore_spec.js
+++ b/test/mongo_ascoltatore_spec.js
@@ -10,4 +10,14 @@ describe("ascoltatori.MongoAscoltatore", function() {
   afterEach(function(done) {
     this.instance.close(done);
   });
+
+  it("should publish a binary payload", function(done) {
+    var that = this;
+    that.instance.sub("hello/*", function(topic, value) {
+      expect(value).to.eql(new Buffer("42"));
+      done();
+    }, function() {
+      that.instance.pub("hello/123", new Buffer("42"));
+    });
+  });
 });


### PR DESCRIPTION
As reported by @scrawl78, MongoAscoltatore do not handle correctly binary payloads. https://github.com/mcollina/mosca/issues/66
