### PR TITLE
Fixed topic slashes on Windows & Forward bug

### DIFF
--- a/lib/prefix_acoltatore.js
+++ b/lib/prefix_acoltatore.js
@@ -38,7 +38,7 @@ PrefixAscoltatore.prototype.wrapCallback = function(callback, next) {
 
 PrefixAscoltatore.prototype._localToParent = function(topic) {
   var newTopic = this._prefix;
-  newTopic += (topic.indexOf('/') < 0) ? '/' : '';
+  newTopic += (topic.indexOf('/') != 0) ? '/' : '';
   newTopic += topic;
   debug("rewriting local topic " + topic + " into " + newTopic);
   return newTopic;


### PR DESCRIPTION
This PR fixes two issues:
1. `PrefixAscoltatore.prototype._localToParent` incorrectly generates the prefixed topic when the broker is running in a Windows environment. `path` incorrectly changes the direction of the slashes.
2. The next one isn't so straight forward and is actually more a bug with Mosca. When used in Mosca,  `PrefixAscoltatore.prototype.wrapCallback` requires a third parameter, `options`. 

Without it, the following error is thrown in Mosca:

```
C:\nodeprojects-other\mosca\lib\client.js:172
    if (options._dedupId === undefined) {
               ^
TypeError: Cannot read property '_dedupId' of undefined
    at Client.forward (C:\nodeprojects-other\mosca\lib\client.js:172:16)
    at handler (C:\nodeprojects-other\mosca\lib\client.js:340:10)
    at Array.callback._prefix_ascoltatore_wrapper [as 0] (C:\nodeprojects-other\mosca\node_modules\ascoltatori\lib\prefix_acoltatore.js:34:7)
    at EventEmitter.TrieAscoltatore.publish (C:\nodeprojects-other\mosca\node_modules\ascoltatori\lib\trie_ascoltatore.js:52:11)
    at EventEmitter.newPublish (C:\nodeprojects-other\mosca\node_modules\ascoltatori\lib\abstract_ascoltatore.js:122:20)
    at Object._onImmediate (C:\nodeprojects-other\mosca\node_modules\ascoltatori\lib\mqtt_ascoltatore.js:72:27)
    at processImmediate [as _immediateCallback] (timers.js:317:15)
```

The error is thrown if a message is published to a Child Broker and the Child Broker has subscribers to that message.

To recreate, start in the `examples/mosca-tree`

Run `mosca -c firsConfig.js -v`
Run `mosca -c secondConfig.js -v`
Run `mosquitto_sub -p 4883 -t "#" -v`
Run `mosquitto_sub -p 4884 -t "hello/world" -v`
Run `mosquitto_pub -t "hello/world" -m "dd" -p 4884`
