### PR TITLE
Pass options to JSON store callback

### DIFF
--- a/lib/json_ascoltatore.js
+++ b/lib/json_ascoltatore.js
@@ -25,7 +25,7 @@ JSONAscoltatore.prototype = Object.create(DecoratorAscoltatore.prototype);
 JSONAscoltatore.prototype.wrapCallback = function(callback, next) {
   var that = this;
   if (!callback._json_ascoltatore_wrapper) {
-    callback._json_ascoltatore_wrapper = function(t, payload) {
+    callback._json_ascoltatore_wrapper = function(t, payload, options) {
       debug("converting from JSON");
       var errored = false;
 
@@ -37,7 +37,7 @@ JSONAscoltatore.prototype.wrapCallback = function(callback, next) {
       }
 
       if (!errored) {
-        callback(t, payload);
+        callback(t, payload, options);
       }
     };
   }


### PR DESCRIPTION
Hey @mcollina,

I am using mosca with a memory backend, and writing custom functionality to pass messages to/from AMQP (I need special functionality in the server) and ran into an issue when trying to send a publish back to the client using the following code:
(topic and payload are just normal strings that come from an AMQP message event)

``` javascript
var mqttMessage = {
    topic: deliveryInfo.routingKey.replace(/\./g, '/'),
    payload: message.data.toString(),
    qos: 0,
    retain: false
};

server.publish(mqttMessage, function(){
    logger.info('Sent response to client');
});
```

I've included the error I was getting below:

```
/Users/chris/Documents/development/git/backend/node_modules/mosca/lib/client.js:201
    if (options._dedupId <= that._lastDedupId) {
               ^
TypeError: Cannot read property '_dedupId' of undefined
    at Client.forward (/Users/chris/Documents/development/git/backend/node_modules/mosca/lib/client.js:201:16)
    at handler (/Users/chris/Documents/development/git/backend/node_modules/mosca/lib/client.js:389:10)
    at Array.callback._json_ascoltatore_wrapper [as 0] (/Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/ascoltatori/lib/json_ascoltatore.js:40:9)
    at EventEmitter.TrieAscoltatore.publish (/Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/ascoltatori/lib/trie_ascoltatore.js:54:11)
    at EventEmitter.newPublish (/Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/ascoltatori/lib/abstract_ascoltatore.js:122:20)
    at /Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/ascoltatori/lib/decorator_ascoltatore.js:125:25
    at fn (/Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/async/lib/async.js:582:34)
    at Object._onImmediate (/Users/chris/Documents/development/git/backend/node_modules/mosca/node_modules/async/lib/async.js:498:34)
    at processImmediate [as _immediateCallback] (timers.js:330:15)
```

Making the changes in this pull request fixes this issue. I'm not sure if this affects anything else, as I don't know where else to test.

Let me know if you need anything else done!

Cheers
Chris
