### PR TITLE
Update qlobber-fsq dependency.

### DIFF
--- a/lib/filesystem_ascoltatore.js
+++ b/lib/filesystem_ascoltatore.js
@@ -96,8 +96,7 @@ FileSystemAscoltatore.prototype.registerDomain = function (domain)
   var ths = this;
 
   domain.on('error', function () {
-    // assume the worst (the error was thrown and the polling stopped)
-    ths._fsq._watching = false;
+    ths._fsq.stop_watching();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "mqtt": "~0.3.8",
     "mongodb": "~1.3.23",
     "eventemitter2": "~0.4.13",
-    "qlobber-fsq": "~0.0.3"
+    "qlobber-fsq": "~0.1.1"
   }
 }


### PR DESCRIPTION
I've updated qlobber-fsq and changed it's API.
There's no real change for filesystem-ascoltatori but since 0.1.x is the version I'll be using going forward, it seems sensible to update the dependency here.
