### PR TITLE
Fix a problem related to Issues #131 Getting duplicate messages using Mongodb as mosca backend.

### DIFF
--- a/lib/mongo_ascoltatore.js
+++ b/lib/mongo_ascoltatore.js
@@ -292,7 +292,7 @@ MongoAscoltatore.prototype._more = function(latest) {
 
     debug('calling the subscriber callback');
 
-    latest = doc._id;
+    latest = latest > doc._id ? latest: doc._id;
     that._lastSuccessfulHandling = latest;
 
     if (!that._closed) {

--- a/test/mongo_ascoltatore_spec.js
+++ b/test/mongo_ascoltatore_spec.js
@@ -122,4 +122,30 @@ describeAscoltatore("mongo", function() {
       setTimeout(done, 3000);
     });
   });
+
+  it("should not duplicate messages when sending messages sequentially", function(done) {
+    this.timeout(5000);
+
+    var that = this;
+    var called = 0;
+    that.instance.sub("hello", function(topic, value) {
+      called++;
+      expect(called).to.be.lessThan(7);
+      expect(value).to.eql(new Buffer("42"));
+    }, function() {
+      setTimeout(function(){
+        that.instance.pub("hello", new Buffer("42"));
+        that.instance.pub("hello", new Buffer("42"));
+        setTimeout(function(){
+          that.instance.pub("hello", new Buffer("42"));
+          that.instance.pub("hello", new Buffer("42"));
+          setTimeout(function(){
+            that.instance.pub("hello", new Buffer("42"));
+            that.instance.pub("hello", new Buffer("42"));
+          },100);
+        },100);
+      },100);
+      setTimeout(done, 3000);
+    });
+  });
 });


### PR DESCRIPTION
Temporarily get rid of the problem by checking *lastest* before replacing it.

https://github.com/mcollina/ascoltatori/issues/131