### PR TITLE
Fix MongoError: No more documents in tailed cursor

### DIFF
--- a/lib/mongo_ascoltatore.js
+++ b/lib/mongo_ascoltatore.js
@@ -259,10 +259,10 @@ MongoAscoltatore.prototype._poll = function(latest) {
   var options = {
     tailable: true,
     awaitdata: true,
-    numberOfRetries: -1
+    numberOfRetries: Number.MAX_VALUE
   };
 
-  this._cursor = this.collection.find({ _id: { $gt: latest } }, options);
+  this._cursor = this.collection.find({ _id: { $gt: latest } }, options).stream();
 
   // we have created only the cursor, now take a look at the messages arrived until now
   this._more(latest);
@@ -278,33 +278,40 @@ MongoAscoltatore.prototype._more = function(latest) {
 
   debug('more');
 
-  that._cursor.each(that._handle(true, function(doc) {
+  that._cursor.on('data', function (doc) {
 
-    var value;
+    that._handle(true, function(doc) {
 
-    if (!doc) {
-      debug('setting the subscriber polling');
-      that._pollTimeout = setTimeout(function() {
-        that._poll(latest);
-      }, that.wait);
-      return;
-    }
+      var value;
 
-    debug('calling the subscriber callback');
-
-    latest = latest > doc._id ? latest: doc._id;
-    that._lastSuccessfulHandling = latest;
-
-    if (!that._closed) {
-      if (doc.value && doc.value.buffer) {
-        value = doc.value.buffer;
-      } else {
-        value = doc.value;
+      if (!doc) {
+        debug('setting the subscriber polling');
+        that._pollTimeout = setTimeout(function() {
+          that._poll(latest);
+        }, that.wait);
+        return;
       }
 
-      that._ascoltatore.publish(doc.topic, value, doc.options);
-    }
-  }));
+      debug('calling the subscriber callback');
+
+      latest = latest > doc._id ? latest: doc._id;
+      that._lastSuccessfulHandling = latest;
+
+      if (!that._closed) {
+        if (doc.value && doc.value.buffer) {
+          value = doc.value.buffer;
+        } else {
+          value = doc.value;
+        }
+
+        that._ascoltatore.publish(doc.topic, value, doc.options);
+      }
+    })(null, doc);
+  });
+
+  that._cursor.on('error', function (err) {
+    debug('Cursor Error:', err);
+  });
 };
 
 MongoAscoltatore.prototype.unsubscribe = function() {


### PR DESCRIPTION
The issue has been described on [mosca/issues/346](https://github.com/mcollina/mosca/issues/346).

For more info : [MongoError: No more documents in tailed cursor](https://jira.mongodb.org/browse/NODE-435)

Found the solution from the below StackOverflow question
[Finding each new document in mongoDB oplog collection using nodejs does not work (cursor seems to become invalid or dead)](http://stackoverflow.com/questions/29540909/finding-each-new-document-in-mongodb-oplog-collection-using-nodejs-does-not-work)