### PR TITLE
Pre-Node4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ after_success:
 language: node_js
 
 node_js:
-  - 5.0
-  - 4.2
-  - 4.0
-  - iojs-v3
   - iojs-v2
   - iojs-v1
   - 0.12
@@ -50,9 +46,3 @@ services:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: MONGODB_VERSION="3.2*"
-    - node_js: 5.0
-    - node_js: 4.2
-    - node_js: 4.0
-    - node_js: iojs-v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,58 @@
 env:
   - MONGODB_VERSION="2.6*"
-  - MONGODB_VERSION="2.8*"
   - MONGODB_VERSION="3.0*"
+  - MONGODB_VERSION="3.2*"
 
 before_install:
-  # MongoDB
+  # GCC-4.8
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  # MongoDB
+  - if [[ "$TRAVIS_NODE_VERSION" != 0.* ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
   - if [ "$MONGODB_VERSION" = "2.4*" ]; then echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list; fi
   - if [ "$MONGODB_VERSION" = "2.6*" ]; then echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" | sudo tee /etc/apt/sources.list.d/mongodb.list; fi
-  - if [ "$MONGODB_VERSION" = "2.8*" ]; then echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/testing multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-2.8.list; fi
-  - if [ "$MONGODB_VERSION" = "3.0*" ]; then echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/testing multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-2.8.list; fi
-  - sudo apt-get update
-  - if [ "$MONGODB_VERSION" = "2.4*" ]; then sudo apt-get install -y mongodb-10gen=`echo $MONGODB_VERSION`; fi
-  - if [ "$MONGODB_VERSION" != "2.4*" ]; then sudo apt-get install -y mongodb-org-server=`echo $MONGODB_VERSION`; fi
+  - if [ "$MONGODB_VERSION" = "3.0*" ]; then echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list; fi
+  - if [ "$MONGODB_VERSION" = "3.2*" ]; then echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/testing multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.1.list; fi
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get install libzmq3-dev
+  - if [ "$MONGODB_VERSION" = "2.4*" ]; then sudo apt-get install -y -qq mongodb-10gen=`echo $MONGODB_VERSION`; fi
+  - if [ "$MONGODB_VERSION" != "2.4*" ]; then sudo apt-get install -y --force-yes -qq mongodb-org-server=`echo $MONGODB_VERSION`; fi
   - mongod --version
   - if [ "$MONGODB_VERSION" = "2.4*" ]; then sudo service mongodb start; fi
-  - sudo apt-get install libzmq3-dev
+  - if [[ "$TRAVIS_NODE_VERSION" != 0.* ]]; then sudo apt-get -y -qq install g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - npm install
+
 before_script:
   - (cd node_modules/mosca/node_modules && rm -rf ascoltatori && mkdir ascoltatori && tar -c --exclude node_modules ../../.. | tar -x -C ascoltatori)
+
 script:
   - npm run coverage
+
 after_success:
   - npm run publish-coverage
+
 language: node_js
+
 node_js:
+  - 5.0
+  - 4.2
+  - 4.0
+  - iojs-v3
   - iojs-v2
   - iojs-v1
   - 0.12
   - 0.10
+
 services:
   - rabbitmq
   - redis-server
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: MONGODB_VERSION="3.2*"
+    - node_js: 5.0
+    - node_js: 4.2
+    - node_js: 4.0
+    - node_js: iojs-v3

--- a/lib/decorator_ascoltatore.js
+++ b/lib/decorator_ascoltatore.js
@@ -57,14 +57,17 @@ DecoratorAscoltatore.prototype.wrapPayload = function(payload, next) {
 
 DecoratorAscoltatore.prototype.on = function(event, callback) {
   this._ascoltatore.on(event, callback);
+  return this;
 };
 
 DecoratorAscoltatore.prototype.once = function(event, callback) {
   this._ascoltatore.once(event, callback);
+  return this;
 };
 
 DecoratorAscoltatore.prototype.removeListener = function(event, callback) {
   this._ascoltatore.removeListener(event, callback);
+  return this;
 };
 
 DecoratorAscoltatore.prototype.subscribe = function(topic, callback, done) {

--- a/lib/mongo_ascoltatore.js
+++ b/lib/mongo_ascoltatore.js
@@ -16,7 +16,7 @@ var async = require("async");
  * It is implemented through the `mongoskin` package.
  *
  * The options are:
- * `url`: the mongodb url (default: 'mongodb://localhost:27017/ascoltatori?auto_reconnect')
+ * `url`: the mongodb url (default: 'mongodb://localhost:27017/ascoltatori?auto_reconnect=true')
  * `pubsubCollection`: where to store the messages on mongodb (default: pubsub)
  * `mongo`: settings for the mongodb connection
  *
@@ -30,12 +30,12 @@ var MongoAscoltatore = function(opts) {
     // old options
     opts.uri = opts.uri || 'mongodb://127.0.0.1/';
     opts.db = opts.db || 'ascoltatori';
-    opts.url = opts.uri + opts.db + '?auto_reconnect';
+    opts.url = opts.uri + opts.db + '?auto_reconnect=true';
     delete opts.db;
   }
 
   this._opts = opts || {};
-  this.url = this._opts.url || 'mongodb://127.0.0.1/ascoltatori?auto_reconnect';
+  this.url = this._opts.url || 'mongodb://127.0.0.1/ascoltatori?auto_reconnect=true';
   this._pubsubCollection = opts.pubsubCollection || 'pubsub';
   this._maxRetry = opts.maxRetry || 5;
   this.mongoOpts = this._opts.mongo || {};

--- a/lib/redis_ascoltatore.js
+++ b/lib/redis_ascoltatore.js
@@ -74,7 +74,10 @@ function createConn(opts, connName) {
   var conn = opts[connName];
   if (conn === undefined) {
     debug("connecting to " + opts.host + ":" + opts.port);
-    conn = opts.redis.createClient(opts.port, opts.host, opts);
+    var redisOpts = {};
+    for (var key in opts)
+      if (typeof opts[key] !== 'object') redisOpts[key] = opts[key]; // Avoid circular reference TypeError
+    conn = opts.redis.createClient(opts.port, opts.host, redisOpts);
   }
   if (opts.password !== undefined) {
     debug("authenticating using password");

--- a/lib/redis_ascoltatore.js
+++ b/lib/redis_ascoltatore.js
@@ -127,6 +127,7 @@ RedisAscoltatore.prototype._startSub = function() {
     });
 
     handler = function(sub, topic, payload) {
+      topic = topic.toString(); // cast to string in case of Buffer instance (nodejs-redis >=2.0)
       debug("new message received for topic " + topic);
       util.defer(function() {
         // we need to skip out this callback, so we do not

--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
     "qlobber": "~0.5.3"
   },
   "optionalDependencies": {
-    "nan": "~2.1.0",
-    "redis": "~2.3.0",
+    "nan": "^2.1.0",
+    "redis": "^2.4.0",
     "hiredis": "^0.4.1",
-    "zmq": "~2.13.0",
+    "zmq": "^2.14.0",
     "amqp": "~0.2.4",
     "mqtt": "^1.5.0",
-    "mongodb": "~2.0.48",
+    "mongodb": "^2.1.2",
     "eventemitter2": "~0.4.14",
     "qlobber-fsq": "~0.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The pub/sub library for node backed by Redis, MongoDB, AMQP (RabbitMQ), ZeroMQ, MQTT (Mosquitto) or just plain node!",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive --bail --reporter spec test",
+    "test": "mocha --recursive --bail --reporter spec test --globals Promise",
     "ci": "mocha --recursive --bail --watch test",
     "coverage": "rm -rf coverage; istanbul cover _mocha -- --reporter spec --bail --globals Promise",
     "publish-coverage": "(cat coverage/lcov.info | coveralls)",
@@ -52,7 +52,7 @@
     "optimist": "^0.6.1",
     "async_bench": "^0.5.1",
     "dox-foundation": "^0.5.6",
-    "mosca": "cybusio/mosca.git#node4",
+    "mosca": "~0.32.1",
     "jshint": "^2.8.0",
     "istanbul": "^0.4.0",
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "optimist": "^0.6.1",
     "async_bench": "^0.5.1",
     "dox-foundation": "^0.5.6",
-    "mosca": "git://github.com/mcollina/mosca.git",
+    "mosca": "cybusio/mosca.git#node4",
     "jshint": "^2.8.0",
     "istanbul": "^0.4.0",
     "coveralls": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -45,34 +45,34 @@
     "David Halls <dave@davedoesdev.com>"
   ],
   "devDependencies": {
-    "mocha": "^2.0.0",
-    "chai": "^1.10.0",
-    "sinon": "^1.10.3",
-    "sinon-chai": "^2.6.0",
-    "optimist": "~0.6.0",
-    "async_bench": "~0.5.0",
-    "dox-foundation": "0.5.4",
+    "mocha": "^2.3.3",
+    "chai": "^3.4.1",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0",
+    "optimist": "^0.6.1",
+    "async_bench": "^0.5.1",
+    "dox-foundation": "^0.5.6",
     "mosca": "git://github.com/mcollina/mosca.git",
-    "jshint": "~2.5.2",
-    "istanbul": "~0.3.0",
-    "coveralls": "~2.11.0",
-    "pre-commit": "0.0.9"
+    "jshint": "^2.8.0",
+    "istanbul": "^0.4.0",
+    "coveralls": "^2.11.4",
+    "pre-commit": "^1.1.2"
   },
   "dependencies": {
-    "async": "~0.9.0",
-    "debug": "^2.0.0",
-    "node-uuid": "~1.4.0",
-    "qlobber": "~0.5.0"
+    "async": "~1.5.0",
+    "debug": "^2.2.0",
+    "node-uuid": "~1.4.3",
+    "qlobber": "~0.5.3"
   },
   "optionalDependencies": {
-    "nan": "~1.8.4",
-    "redis": "~0.12.1",
-    "hiredis": "^0.4.0",
-    "zmq": "~2.11.0",
+    "nan": "~2.1.0",
+    "redis": "~2.3.0",
+    "hiredis": "^0.4.1",
+    "zmq": "~2.13.0",
     "amqp": "~0.2.4",
-    "mqtt": "^1.0.0",
-    "mongodb": "~2.0.33",
+    "mqtt": "^1.5.0",
+    "mongodb": "~2.0.48",
     "eventemitter2": "~0.4.14",
-    "qlobber-fsq": "~0.3.0"
+    "qlobber-fsq": "~0.3.1"
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -48,7 +48,7 @@ global.MQTTSettings = function() {
 
 global.mongoSettings = function() {
   return {
-    url: 'mongodb://127.0.0.1/ascoltatoriTests?auto_reconnect',
+    url: 'mongodb://127.0.0.1/ascoltatoriTests?auto_reconnect=true',
     pubsubCollection: 'pubsub',
     json: false,
     mongo: {} // put here your mongo-specific options!

--- a/test/redis_ascoltatore_spec.js
+++ b/test/redis_ascoltatore_spec.js
@@ -44,8 +44,8 @@ describeAscoltatore("redis", function() {
   });
 
   it('should get the redis client for publish already created', function(done) {
-    var opts = redisSettings()
-      , redisOpts = {};
+    var opts = redisSettings();
+    var redisOpts = {};
     for (var key in opts)
       if (typeof opts[key] !== 'object') redisOpts[key] = opts[key]; // Avoid circular reference TypeError
 
@@ -59,8 +59,8 @@ describeAscoltatore("redis", function() {
   });
 
   it('should get the redis client for subscribing already created', function(done) {
-    var opts = redisSettings()
-      , redisOpts = {};
+    var opts = redisSettings();
+    var redisOpts = {};
     for (var key in opts)
       if (typeof opts[key] !== 'object') redisOpts[key] = opts[key]; // Avoid circular reference TypeError;
 

--- a/test/redis_ascoltatore_spec.js
+++ b/test/redis_ascoltatore_spec.js
@@ -44,8 +44,12 @@ describeAscoltatore("redis", function() {
   });
 
   it('should get the redis client for publish already created', function(done) {
-    var opts = redisSettings();
-    var initialConnection = opts.redis.createClient(opts.port, opts.host, opts);
+    var opts = redisSettings()
+      , redisOpts = {};
+    for (var key in opts)
+      if (typeof opts[key] !== 'object') redisOpts[key] = opts[key]; // Avoid circular reference TypeError
+
+    var initialConnection = opts.redis.createClient(opts.port, opts.host, redisOpts);
     opts.client_conn = initialConnection;
     var that = this;
     that.instance = new ascoltatori.RedisAscoltatore(opts);
@@ -55,8 +59,12 @@ describeAscoltatore("redis", function() {
   });
 
   it('should get the redis client for subscribing already created', function(done) {
-    var opts = redisSettings();
-    var initialConnection = opts.redis.createClient(opts.port, opts.host, opts);
+    var opts = redisSettings()
+      , redisOpts = {};
+    for (var key in opts)
+      if (typeof opts[key] !== 'object') redisOpts[key] = opts[key]; // Avoid circular reference TypeError;
+
+    var initialConnection = opts.redis.createClient(opts.port, opts.host, redisOpts);
     opts.sub_conn = initialConnection;
     var that = this;
     that.instance = new ascoltatori.RedisAscoltatore(opts);


### PR DESCRIPTION
This PR contains all proposed changes from @dario1985 from https://github.com/mcollina/ascoltatori/pull/137 except adding node4 and the allowed failures to travis. 

I have a local Mosca that works together with this version. Thus I propose we release this PR to npm as version 1.1.1. After that, I will file the PR for mosca which then depends on ascoltatori@1.1.1 and zmq@2.14.0. 

After this mosca release will be published to npm (as e.g. 0.32.2), all node4 barriers for ascoltatori should be gone.