### PR TITLE
Update qlobber-fsq dependency to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mongodb": "^2.1.18",
     "kerberos": "~0.0",
     "eventemitter2": "^1.0.3",
-    "qlobber-fsq": "~2.0.0",
+    "qlobber-fsq": "~3.0.0",
     "kafka-node": "~0.3.2"
   }
 }


### PR DESCRIPTION
It's probably worth updating ascoltatori to qlobber-fsq 3.0.0 because it now hex-encodes topics into message filenames by default. This reduces the likelihood of errors due to topics containing characters which happen to be invalid for the underlying filesystem.
