### PR TITLE
Syntax fix for Kafka settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ var settings = {
   type: 'kafka',
   json: false,
   kafka: require("kafka-node"),
-  connectString: "localhost:2181",
+  connectionString: "localhost:2181",
   clientId: "ascoltatori",
   groupId: "ascoltatori",
   defaultEncoding: "utf8",


### PR DESCRIPTION
Spent too long trying to debug why connections wouldn't connect properly; finally stepped through the source and saw that it looks for `connectionString` rather than `connectString` like the documentation shows.