### PR TITLE
Add "durable: false" option to AMQPLibAscoltatore 

### DIFF
--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -93,7 +93,7 @@ AMQPLibAscoltatore.prototype._startConn = function () {
       function(callback){
         debug('channel created');
         that._queue = util.buildIdentifier();
-        that._channel.assertQueue(that._queue, null, wrap(callback));
+        that._channel.assertQueue(that._queue, {durable: false}, wrap(callback));
       },
 
       function (callback){


### PR DESCRIPTION
The default value of 'durable' parameter is 'true'. 