### PR TITLE
Added retry mechanism for isCapped check

### DIFF
--- a/lib/mongo_ascoltatore.js
+++ b/lib/mongo_ascoltatore.js
@@ -226,15 +226,30 @@ MongoAscoltatore.prototype._handleCursorClosed = function (latest) {
  * @param latest
  * @private
  */
-MongoAscoltatore.prototype._checkCappedAndPoll = function(latest) {
+MongoAscoltatore.prototype._checkCappedAndPoll = function(latest, retryCount) {
   debug('checkCappedAndPoll');
   var that = this;
   this.collection.isCapped(function(err, isCapped) {
-    if (err) {
-      debug('checkCappedAndPoll -> Cannot stat isCapped. Give up');
-      that.emit('error', new Error('Cannot stat if collection is capped or not'));
-      that._handlingCursorFailure = false;
-      return;
+    if (err) 
+    {
+      if(!retryCount)
+          retryCount=0;
+      if(retryCount<that._maxRetry)
+      {
+        debug('checkCappedAndPoll -> Cannot stat isCapped. Retry');
+        retryCount++
+        setTimeout(function(){
+            that._checkCappedAndPoll(latest, retryCount);
+        },100*retryCount)
+
+        return;
+      }else{
+        debug('checkCappedAndPoll -> Cannot stat isCapped. Give up');
+
+        that.emit('error', new Error('Cannot stat if collection is capped or not'));
+        that._handlingCursorFailure = false;
+        return;
+      }
     }
     if (!isCapped) {
       debug('checkCappedAndPoll -> Collection is not capped. Give up');


### PR DESCRIPTION
Please note: When the database is taken down at 

> handleCursorClosed ->  We're now ready. Poll
> checkCappedAndPoll
> checkCappedAndPoll -> Cannot stat isCapped. Retry
> checkCappedAndPoll

and restarted after a minute or so, nothing happens.

This also happens my in your 
> handleCursorClosed -> Wait for the database to be connected

I think it keeps waiting for the mongodb to reply, but doesn't get any timeout error from mongodb driver.