### PR TITLE
AMQPLib: Allow queue and durability to be part of the configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - mkdir -p data/db
   - mongod --dbpath=data/db > /dev/null &
   - sleep 5
-  - wget http://www.us.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz -O kafka.tgz
+  - wget http://www.us.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz -O kafka.tgz
   - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
   - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
   - sleep 10

--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ var settings = {
   type: 'amqplib',
   json: false,
   amqp: require('amqplib/callback_api'),
-  exchange: 'ascolatore5672'
+  exchange: 'ascolatore5672',
+  queue: 'queueName',
+  durableQueue: true
 };
 
 ascoltatori.build(settings, function (err, ascoltatore) {

--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -93,7 +93,7 @@ AMQPLibAscoltatore.prototype._startConn = function () {
       function(callback){
         debug('channel created');
         that._queue = that._opts.queue || util.buildIdentifier();
-        that._channel.assertQueue(that._queue, {durable: (that._opts.durableQueue !== false)}, wrap(callback));
+        that._channel.assertQueue(that._queue, {durable: !!that._opts.durableQueue}, wrap(callback));
       },
 
       function (callback){

--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -145,7 +145,7 @@ AMQPLibAscoltatore.prototype.subscribe = function subscribe(topic, callback, don
 AMQPLibAscoltatore.prototype.publish = function publish(topic, message, done) {
   this._raiseIfClosed();
 
-  debug("new message published to " + topic);
+  debug("new message published to " + this._pubTopic(topic));
 
   this._channel.publish(this._opts.exchange, this._pubTopic(topic), new Buffer(String(message)));
   defer(done);

--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -199,7 +199,7 @@ AMQPLibAscoltatore.prototype.close = function close(done) {
     };
 
     this._client_conn.on("close", doClose);
-    this._channel.deleteQueue(this._queue);
+    this._channel.deleteQueue(this._queue, { "ifUnused": true, "ifEmpty": true });
     this._channel.close();
 
     this._client_conn.close();

--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -92,7 +92,7 @@ AMQPLibAscoltatore.prototype._startConn = function () {
 
       function(callback){
         debug('channel created');
-        that._queue = util.buildIdentifier();
+        that._queue = that._opts.exchange || util.buildIdentifier();
         that._channel.assertQueue(that._queue, {durable: false}, wrap(callback));
       },
 

--- a/lib/amqplib_ascoltatore.js
+++ b/lib/amqplib_ascoltatore.js
@@ -92,8 +92,8 @@ AMQPLibAscoltatore.prototype._startConn = function () {
 
       function(callback){
         debug('channel created');
-        that._queue = that._opts.exchange || util.buildIdentifier();
-        that._channel.assertQueue(that._queue, {durable: false}, wrap(callback));
+        that._queue = that._opts.queue || util.buildIdentifier();
+        that._channel.assertQueue(that._queue, {durable: (that._opts.durableQueue !== false)}, wrap(callback));
       },
 
       function (callback){


### PR DESCRIPTION
**Why?**
In AMQP mode, Ascoltatori creates a queue using an `asc_${uuid()}` as the name every time it is initialized. Also, it checks to ensure that the queue is not durable.

**What is the problem?**
The new queue(s) are not bound to an exchange, or a routing key - since that is not part of the standard configuration. Which means, in turn, that the Administrators have to do something to ensure that each new queue is bound to an exchange with a routing key. In large scale systems, this is obviously not an option.

**What does this PR do?**
Very simply, it allows for the name and durability of the queue to be specified as part of the configuration for AMQPLib.

**Benefits**
RabbitMQ Administrators can now ask the DevOps folks to use a specific queue as part of the deployment process.

So, for example, if there is a cluster of servers that use a specific Exchange / Queue combination for receiving logs, audit trails, etc., they will all use the same queue with the same routing key.  This allows for round-robin message dispatch by a "topic" exchange - essentially, a load-balanced use-case.