### PR TITLE
Error if a  Redis TLS url is specified

### DIFF
--- a/lib/redis_ascoltatore.js
+++ b/lib/redis_ascoltatore.js
@@ -62,6 +62,9 @@ function createConn(opts, connName) {
   var conn = opts[connName];
   if (conn === undefined) {
     debug("connecting with ", opts);
+    if (opts.url && /^rediss:/.test(opts.url)) {
+      throw new Error("Redis TLS protocol not supported");
+    }
     conn = new Redis(opts);
   }
   return conn;


### PR DESCRIPTION
When using a managed Redis database, a `url` with `rediss://` is used for the Redis options, as supported by the latest `ioredis.`

Currently with the legacy `ioredis` dependency, the `url` with `rediss://` option is ignored and the connection defaults silently to `localhost:6379.` The module may appear to work unintentionally if there is a localhost Redis.  

This proposed change will ensure that this module "fails early" and thereby reduce debugging time.

This change would have to be removed when the `ioredis` dependency is upgraded e.g. to `^4.14.1`